### PR TITLE
Sub-B: introduce declarative content layer (src/content)

### DIFF
--- a/src/content/focus.ts
+++ b/src/content/focus.ts
@@ -1,0 +1,13 @@
+export type FocusItem = {
+  title: string;
+  description: string;
+  highlights?: string[];
+};
+
+export const currentFocus: FocusItem[] = [
+  {
+    title: "Governable software systems",
+    description: "Identity, authority, traceability — policy-first systems thinking applied to real repos.",
+    highlights: ["ICE", "PSC standards", "Public proof surfaces"],
+  },
+];

--- a/src/content/links.ts
+++ b/src/content/links.ts
@@ -1,0 +1,14 @@
+export type ExternalLink = {
+  id: string;
+  label: string;
+  href: string;
+};
+
+export const links = {
+  github: { id: "github", label: "GitHub", href: "https://github.com/francescomaiomascio" },
+  medium: { id: "medium", label: "Medium", href: "https://medium.com/@francescomaiomascio" },
+  linkedin: { id: "linkedin", label: "LinkedIn", href: "https://www.linkedin.com/in/francesco-maiomascio/" },
+  gumroad: { id: "gumroad", label: "Gumroad", href: "https://maiomascio.gumroad.com" }, // aggiorna se diverso
+} as const;
+
+export const primaryLinks: ExternalLink[] = Object.values(links);

--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -1,0 +1,27 @@
+export type Project = {
+  id: string;
+  name: string;
+  description: string;
+  href?: string;
+  status?: "active" | "draft" | "planned";
+  tags?: string[];
+};
+
+export const projects: Project[] = [
+  {
+    id: "ice",
+    name: "ICE",
+    description: "Modular ecosystem for governable software execution and governance surfaces.",
+    href: "https://github.com/francescomaiomascio?tab=repositories",
+    status: "active",
+    tags: ["runtime", "governance", "identity"],
+  },
+  {
+    id: "psc",
+    name: "Project Standard Core (PSC)",
+    description: "Policy-first standards and templates for governable projects.",
+    href: "https://github.com/francescomaiomascio",
+    status: "active",
+    tags: ["standards", "governance", "templates"],
+  },
+];

--- a/src/content/writing.ts
+++ b/src/content/writing.ts
@@ -1,0 +1,17 @@
+export type WritingItem = {
+  id: string;
+  title: string;
+  href: string;
+  series?: string;
+  platform?: "medium" | "external";
+};
+
+export const writing: WritingItem[] = [
+  {
+    id: "psc-a1",
+    title: "Policy Before Tooling: Why Most Software Projects Are Ungovernable",
+    href: "https://medium.com/@francescomaiomascio", // sostituisci col link diretto
+    series: "PSC",
+    platform: "medium",
+  },
+];


### PR DESCRIPTION
## Context
Closes #3 

This PR continues the site refactor by introducing a small declarative content layer, so pages consume structured maps instead of hardcoded link lists and one-off content fragments.

## What changed
- Added `src/content/` as an explicit content schema:
  - `focus.ts` (current focus)
  - `projects.ts` (project map)
  - `writing.ts` (writing map)
  - `links.ts` (canonical external links)
- Updated top-level pages to consume `src/content` (no hardcoded mappings inside page logic).

## Scope limits
- No visual redesign / copy polish
- No dynamic fetching, markdown parsing, or CMS behavior
- No backend/auth/newsletter work

## Verification
- `npm run build` (local): ✅ green
- Routes: `/`, `/about`, `/projects`, `/writing` render using `src/content`

## Notes
This establishes the contract: structure/routing stays stable while content can evolve by editing only `src/content/*`.